### PR TITLE
Fix default breakpoints conditions

### DIFF
--- a/lib/src/widget_builders.dart
+++ b/lib/src/widget_builders.dart
@@ -84,11 +84,11 @@ DeviceScreenType getDeviceType(MediaQueryData mediaQuery,
   }
 
   // If no user defined definitions are passed through use the defaults
-  if (deviceWidth > 950) {
+  if (deviceWidth >= 950) {
     return DeviceScreenType.Desktop;
   }
 
-  if (deviceWidth > 600) {
+  if (deviceWidth >= 600) {
     return DeviceScreenType.Tablet;
   }
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: responsive_builder
 description: A set of widgets that can be used to define a readable responsive UI for widgets.
-version: 0.1.6
+version: 0.1.7
 homepage: https://github.com/FilledStacks/responsive_builder
 
 environment:


### PR DESCRIPTION
I fixed the conditions of the breakpoints to be greater than or **equal** cause 600 should be included for small tablets and was not included in the condition, the same for 950 on desktop.