### PR TITLE
Add support for refined layout sizes

### DIFF
--- a/lib/src/device_screen_type.dart
+++ b/lib/src/device_screen_type.dart
@@ -12,3 +12,5 @@ enum DeviceScreenType {
   desktop,
   watch
 }
+
+enum RefinedSize { small, normal, large, extraLarge }

--- a/lib/src/helpers.dart
+++ b/lib/src/helpers.dart
@@ -15,7 +15,6 @@ DeviceScreenType getDeviceType(
 
   if (kIsWeb) {
     deviceWidth = size.width;
-    //return DeviceScreenType.desktop;
   }
 
   // Replaces the defaults with the user defined definitions

--- a/lib/src/helpers.dart
+++ b/lib/src/helpers.dart
@@ -3,6 +3,7 @@ import 'package:flutter/material.dart';
 import 'package:responsive_builder/src/responsive_sizing_config.dart';
 import 'package:responsive_builder/src/sizing_information.dart';
 
+import '../responsive_builder.dart';
 import 'device_screen_type.dart';
 
 /// Returns the [DeviceScreenType] that the application is currently running on
@@ -14,6 +15,7 @@ DeviceScreenType getDeviceType(
 
   if (kIsWeb) {
     deviceWidth = size.width;
+    //return DeviceScreenType.desktop;
   }
 
   // Replaces the defaults with the user defined definitions
@@ -49,9 +51,10 @@ DeviceScreenType getDeviceType(
 
 /// Returns the [RefindedSize] for each device that the application is currently running on
 RefinedSize getRefinedSize(
-  DeviceScreenType deviceScreenType, [
+  Size size, [
   RefinedBreakpoints refinedBreakpoint,
 ]) {
+  DeviceScreenType deviceScreenType = getDeviceType(size);
   double deviceWidth = size.shortestSide;
 
   if (kIsWeb) {
@@ -69,7 +72,7 @@ RefinedSize getRefinedSize(
         return RefinedSize.large;
       }
 
-      if (deviceWidth < refinedBreakpoint.desktopNormal) {
+      if (deviceWidth > refinedBreakpoint.desktopNormal) {
         return RefinedSize.normal;
       }
 
@@ -87,7 +90,7 @@ RefinedSize getRefinedSize(
         return RefinedSize.large;
       }
 
-      if (deviceWidth < refinedBreakpoint.tabletNormal) {
+      if (deviceWidth > refinedBreakpoint.tabletNormal) {
         return RefinedSize.normal;
       }
 
@@ -105,7 +108,7 @@ RefinedSize getRefinedSize(
         return RefinedSize.large;
       }
 
-      if (deviceWidth < refinedBreakpoint.mobileNormal) {
+      if (deviceWidth > refinedBreakpoint.mobileNormal) {
         return RefinedSize.normal;
       }
 
@@ -133,7 +136,7 @@ RefinedSize getRefinedSize(
         return RefinedSize.large;
       }
 
-      if (deviceWidth <
+      if (deviceWidth >=
           ResponsiveSizingConfig.instance.refinedBreakpoints.desktopNormal) {
         return RefinedSize.normal;
       }
@@ -156,7 +159,7 @@ RefinedSize getRefinedSize(
         return RefinedSize.large;
       }
 
-      if (deviceWidth <
+      if (deviceWidth >=
           ResponsiveSizingConfig.instance.refinedBreakpoints.tabletNormal) {
         return RefinedSize.normal;
       }
@@ -179,7 +182,7 @@ RefinedSize getRefinedSize(
         return RefinedSize.large;
       }
 
-      if (deviceWidth <
+      if (deviceWidth >=
           ResponsiveSizingConfig.instance.refinedBreakpoints.mobileNormal) {
         return RefinedSize.normal;
       }
@@ -231,7 +234,7 @@ T getValueForRefinedSize<T>({
   T large,
   T extraLarge,
 }) {
-  var refinedSize = getRefinedSize(getDeviceType(MediaQuery.of(context).size));
+  var refinedSize = getRefinedSize(MediaQuery.of(context).size);
   // If we're at extra large size
   if (refinedSize == RefinedSize.extraLarge) {
     // If we have supplied the extra large layout then display that
@@ -245,6 +248,13 @@ T getValueForRefinedSize<T>({
     if (large != null) return large;
     // If no large layout is supplied we want to check if we have the size below it and display that
     if (normal != null) return normal;
+  }
+
+  if (refinedSize == RefinedSize.normal) {
+    // If we have supplied the normal layout then display that
+    if (normal != null) return normal;
+    // If no normal layout is supplied we want to check if we have the size below it and display that
+    if (small != null) return small;
   }
 
   if (refinedSize == RefinedSize.small && small != null) {

--- a/lib/src/helpers.dart
+++ b/lib/src/helpers.dart
@@ -47,6 +47,153 @@ DeviceScreenType getDeviceType(
   return DeviceScreenType.mobile;
 }
 
+/// Returns the [RefindedSize] for each device that the application is currently running on
+RefinedSize getRefinedSize(
+  DeviceScreenType deviceScreenType, [
+  RefinedBreakpoints refinedBreakpoint,
+]) {
+  double deviceWidth = size.shortestSide;
+
+  if (kIsWeb) {
+    deviceWidth = size.width;
+  }
+
+  // Replaces the defaults with the user defined definitions
+  if (refinedBreakpoint != null) {
+    if (deviceScreenType == DeviceScreenType.desktop) {
+      if (deviceWidth > refinedBreakpoint.desktopExtraLarge) {
+        return RefinedSize.extraLarge;
+      }
+
+      if (deviceWidth > refinedBreakpoint.desktopLarge) {
+        return RefinedSize.large;
+      }
+
+      if (deviceWidth < refinedBreakpoint.desktopNormal) {
+        return RefinedSize.normal;
+      }
+
+      if (deviceWidth < refinedBreakpoint.desktopSmall) {
+        return RefinedSize.small;
+      }
+    }
+
+    if (deviceScreenType == DeviceScreenType.tablet) {
+      if (deviceWidth > refinedBreakpoint.tabletExtraLarge) {
+        return RefinedSize.extraLarge;
+      }
+
+      if (deviceWidth > refinedBreakpoint.tabletLarge) {
+        return RefinedSize.large;
+      }
+
+      if (deviceWidth < refinedBreakpoint.tabletNormal) {
+        return RefinedSize.normal;
+      }
+
+      if (deviceWidth < refinedBreakpoint.tabletSmall) {
+        return RefinedSize.small;
+      }
+    }
+
+    if (deviceScreenType == DeviceScreenType.mobile) {
+      if (deviceWidth > refinedBreakpoint.mobileExtraLarge) {
+        return RefinedSize.extraLarge;
+      }
+
+      if (deviceWidth > refinedBreakpoint.mobileLarge) {
+        return RefinedSize.large;
+      }
+
+      if (deviceWidth < refinedBreakpoint.mobileNormal) {
+        return RefinedSize.normal;
+      }
+
+      if (deviceWidth < refinedBreakpoint.mobileSmall) {
+        return RefinedSize.small;
+      }
+    }
+
+    if (deviceScreenType == DeviceScreenType.watch) {
+      return RefinedSize.normal;
+    }
+  } else {
+    // If no user defined definitions are passed through use the defaults
+
+    // Desktop
+    if (deviceScreenType == DeviceScreenType.desktop) {
+      if (deviceWidth >=
+          ResponsiveSizingConfig
+              .instance.refinedBreakpoints.desktopExtraLarge) {
+        return RefinedSize.extraLarge;
+      }
+
+      if (deviceWidth >=
+          ResponsiveSizingConfig.instance.refinedBreakpoints.desktopLarge) {
+        return RefinedSize.large;
+      }
+
+      if (deviceWidth <
+          ResponsiveSizingConfig.instance.refinedBreakpoints.desktopNormal) {
+        return RefinedSize.normal;
+      }
+
+      if (deviceWidth <
+          ResponsiveSizingConfig.instance.refinedBreakpoints.desktopSmall) {
+        return RefinedSize.small;
+      }
+    }
+
+    // Tablet
+    if (deviceScreenType == DeviceScreenType.tablet) {
+      if (deviceWidth >=
+          ResponsiveSizingConfig.instance.refinedBreakpoints.tabletExtraLarge) {
+        return RefinedSize.extraLarge;
+      }
+
+      if (deviceWidth >=
+          ResponsiveSizingConfig.instance.refinedBreakpoints.tabletLarge) {
+        return RefinedSize.large;
+      }
+
+      if (deviceWidth <
+          ResponsiveSizingConfig.instance.refinedBreakpoints.tabletNormal) {
+        return RefinedSize.normal;
+      }
+
+      if (deviceWidth <
+          ResponsiveSizingConfig.instance.refinedBreakpoints.tabletSmall) {
+        return RefinedSize.small;
+      }
+    }
+
+    // Mobile
+    if (deviceScreenType == DeviceScreenType.mobile) {
+      if (deviceWidth >=
+          ResponsiveSizingConfig.instance.refinedBreakpoints.mobileExtraLarge) {
+        return RefinedSize.extraLarge;
+      }
+
+      if (deviceWidth >=
+          ResponsiveSizingConfig.instance.refinedBreakpoints.mobileLarge) {
+        return RefinedSize.large;
+      }
+
+      if (deviceWidth <
+          ResponsiveSizingConfig.instance.refinedBreakpoints.mobileNormal) {
+        return RefinedSize.normal;
+      }
+
+      if (deviceWidth <
+          ResponsiveSizingConfig.instance.refinedBreakpoints.mobileSmall) {
+        return RefinedSize.small;
+      }
+    }
+  }
+
+  return RefinedSize.normal;
+}
+
 /// Will return one of the values passed in for the device it's running on
 T getValueForScreenType<T>({
   BuildContext context,
@@ -74,6 +221,38 @@ T getValueForScreenType<T>({
 
   // If none of the layouts above are supplied or we're on the mobile layout then we show the mobile layout
   return mobile;
+}
+
+/// Will return one of the values passed in for the refined size
+T getValueForRefinedSize<T>({
+  BuildContext context,
+  T small,
+  T normal,
+  T large,
+  T extraLarge,
+}) {
+  var refinedSize = getRefinedSize(getDeviceType(MediaQuery.of(context).size));
+  // If we're at extra large size
+  if (refinedSize == RefinedSize.extraLarge) {
+    // If we have supplied the extra large layout then display that
+    if (extraLarge != null) return extraLarge;
+    // If no extra large layout is supplied we want to check if we have the size below it and display that
+    if (large != null) return large;
+  }
+
+  if (refinedSize == RefinedSize.large) {
+    // If we have supplied the large layout then display that
+    if (large != null) return large;
+    // If no large layout is supplied we want to check if we have the size below it and display that
+    if (normal != null) return normal;
+  }
+
+  if (refinedSize == RefinedSize.small && small != null) {
+    return small;
+  }
+
+  // If none of the layouts above are supplied or we're on the normal size layout then we show the normal layout
+  return normal;
 }
 
 class ScreenTypeValueBuilder<T> {

--- a/lib/src/responsive_sizing_config.dart
+++ b/lib/src/responsive_sizing_config.dart
@@ -19,6 +19,27 @@ class ResponsiveSizingConfig {
 
   ScreenBreakpoints _customBreakPoints;
 
+  static const RefinedBreakpoints _defaultRefinedBreakPoints =
+      const RefinedBreakpoints(
+    // Desktop
+    desktopExtraLarge: 2160,
+    desktopLarge: 1440,
+    desktopNormal: 1080,
+    desktopSmall: 720,
+    // Tablet
+    tabletExtraLarge: 1280,
+    tabletLarge: 1024,
+    tabletNormal: 768,
+    tabletSmall: 600,
+    // Mobile
+    mobileExtraLarge: 600,
+    mobileLarge: 414,
+    mobileNormal: 375,
+    mobileSmall: 320,
+  );
+
+  RefinedBreakpoints _customRefinedBreakPoints;
+
   /// Set the breakPoints which will then be returned through the [breakpoints]
   void setCustomBreakpoints(ScreenBreakpoints customBreakpoints) {
     _customBreakPoints = customBreakpoints;
@@ -26,4 +47,13 @@ class ResponsiveSizingConfig {
 
   ScreenBreakpoints get breakpoints =>
       _customBreakPoints ?? _defaultBreakPoints;
+
+  /// Set the refinedBreakPoints which will then be returned through the [refinedBreakpoints]
+  void setCustomRefinedBreakpoints(
+      RefinedBreakpoints customRefinedBreakpoints) {
+    _customRefinedBreakPoints = customRefinedBreakpoints;
+  }
+
+  RefinedBreakpoints get refinedBreakpoints =>
+      _customRefinedBreakPoints ?? _defaultRefinedBreakPoints;
 }

--- a/lib/src/responsive_sizing_config.dart
+++ b/lib/src/responsive_sizing_config.dart
@@ -22,17 +22,17 @@ class ResponsiveSizingConfig {
   static const RefinedBreakpoints _defaultRefinedBreakPoints =
       const RefinedBreakpoints(
     // Desktop
-    desktopExtraLarge: 2160,
-    desktopLarge: 1440,
-    desktopNormal: 1080,
-    desktopSmall: 720,
+    desktopExtraLarge: 4096,
+    desktopLarge: 3840,
+    desktopNormal: 1920,
+    desktopSmall: 950,
     // Tablet
-    tabletExtraLarge: 1280,
-    tabletLarge: 1024,
+    tabletExtraLarge: 900,
+    tabletLarge: 850,
     tabletNormal: 768,
     tabletSmall: 600,
     // Mobile
-    mobileExtraLarge: 600,
+    mobileExtraLarge: 480,
     mobileLarge: 414,
     mobileNormal: 375,
     mobileSmall: 320,

--- a/lib/src/responsive_sizing_config.dart
+++ b/lib/src/responsive_sizing_config.dart
@@ -41,18 +41,16 @@ class ResponsiveSizingConfig {
   RefinedBreakpoints _customRefinedBreakPoints;
 
   /// Set the breakPoints which will then be returned through the [breakpoints]
-  void setCustomBreakpoints(ScreenBreakpoints customBreakpoints) {
+  void setCustomBreakpoints(ScreenBreakpoints customBreakpoints,
+      {RefinedBreakpoints customRefinedBreakpoints}) {
     _customBreakPoints = customBreakpoints;
+    if (customRefinedBreakpoints != null) {
+      _customRefinedBreakPoints = customRefinedBreakpoints;
+    }
   }
 
   ScreenBreakpoints get breakpoints =>
       _customBreakPoints ?? _defaultBreakPoints;
-
-  /// Set the refinedBreakPoints which will then be returned through the [refinedBreakpoints]
-  void setCustomRefinedBreakpoints(
-      RefinedBreakpoints customRefinedBreakpoints) {
-    _customRefinedBreakPoints = customRefinedBreakpoints;
-  }
 
   RefinedBreakpoints get refinedBreakpoints =>
       _customRefinedBreakPoints ?? _defaultRefinedBreakPoints;

--- a/lib/src/sizing_information.dart
+++ b/lib/src/sizing_information.dart
@@ -4,6 +4,7 @@ import 'device_screen_type.dart';
 /// Contains sizing information to make responsive choices for the current screen
 class SizingInformation {
   final DeviceScreenType deviceScreenType;
+  final RefinedSize refinedSize;
   final Size screenSize;
   final Size localWidgetSize;
 
@@ -15,15 +16,26 @@ class SizingInformation {
 
   bool get isWatch => deviceScreenType == DeviceScreenType.watch;
 
+  // Refined
+
+  bool get isExtraLarge => refinedSize == RefinedSize.extraLarge;
+
+  bool get isLarge => refinedSize == RefinedSize.large;
+
+  bool get isNormal => refinedSize == RefinedSize.normal;
+
+  bool get isSmall => refinedSize == RefinedSize.small;
+
   SizingInformation({
     this.deviceScreenType,
+    this.refinedSize,
     this.screenSize,
     this.localWidgetSize,
   });
 
   @override
   String toString() {
-    return 'DeviceType:$deviceScreenType ScreenSize:$screenSize LocalWidgetSize:$localWidgetSize';
+    return 'DeviceType:$deviceScreenType RefinedSize:$refinedSize ScreenSize:$screenSize LocalWidgetSize:$localWidgetSize';
   }
 }
 
@@ -44,5 +56,49 @@ class ScreenBreakpoints {
   @override
   String toString() {
     return "Desktop: $desktop, Tablet: $tablet, Watch: $watch";
+  }
+}
+
+/// Manually define refined breakpoints
+///
+/// Overrides the defaults
+class RefinedBreakpoints {
+  final double mobileSmall;
+  final double mobileNormal;
+  final double mobileLarge;
+  final double mobileExtraLarge;
+
+  final double tabletSmall;
+  final double tabletNormal;
+  final double tabletLarge;
+  final double tabletExtraLarge;
+
+  final double desktopSmall;
+  final double desktopNormal;
+  final double desktopLarge;
+  final double desktopExtraLarge;
+
+  const RefinedBreakpoints({
+    @required this.mobileSmall,
+    @required this.mobileNormal,
+    @required this.mobileLarge,
+    @required this.mobileExtraLarge,
+
+    @required this.tabletSmall,
+    @required this.tabletNormal,
+    @required this.tabletLarge,
+    @required this.tabletExtraLarge,
+
+    @required this.desktopSmall,
+    @required this.desktopNormal,
+    @required this.desktopLarge,
+    @required this.desktopExtraLarge,
+  });
+
+  @override
+  String toString() {
+    return "Desktop: Small - $desktopSmall Normal - $desktopNormal Large - $desktoplarge ExtraLarge - $desktopExtraLarge
+    \nTablet: Small - $tabletSmall Normal - $tabletNormal Large - $tabletlarge ExtraLarge - $tabletExtraLarge 
+    \nMobile: Small - $mobileSmall Normal - $mobileNormal Large - $mobilelarge ExtraLarge - $mobileExtraLarge";
   }
 }

--- a/lib/src/sizing_information.dart
+++ b/lib/src/sizing_information.dart
@@ -79,26 +79,24 @@ class RefinedBreakpoints {
   final double desktopExtraLarge;
 
   const RefinedBreakpoints({
-    @required this.mobileSmall,
-    @required this.mobileNormal,
-    @required this.mobileLarge,
-    @required this.mobileExtraLarge,
-
-    @required this.tabletSmall,
-    @required this.tabletNormal,
-    @required this.tabletLarge,
-    @required this.tabletExtraLarge,
-
-    @required this.desktopSmall,
-    @required this.desktopNormal,
-    @required this.desktopLarge,
-    @required this.desktopExtraLarge,
+    this.mobileSmall = 320,
+    this.mobileNormal = 375,
+    this.mobileLarge = 414,
+    this.mobileExtraLarge = 480,
+    this.tabletSmall = 600,
+    this.tabletNormal = 768,
+    this.tabletLarge = 850,
+    this.tabletExtraLarge = 900,
+    this.desktopSmall = 950,
+    this.desktopNormal = 1920,
+    this.desktopLarge = 3840,
+    this.desktopExtraLarge = 4096,
   });
 
   @override
   String toString() {
-    return "Desktop: Small - $desktopSmall Normal - $desktopNormal Large - $desktoplarge ExtraLarge - $desktopExtraLarge
-    \nTablet: Small - $tabletSmall Normal - $tabletNormal Large - $tabletlarge ExtraLarge - $tabletExtraLarge 
-    \nMobile: Small - $mobileSmall Normal - $mobileNormal Large - $mobilelarge ExtraLarge - $mobileExtraLarge";
+    return "Desktop: Small - $desktopSmall Normal - $desktopNormal Large - $desktopLarge ExtraLarge - $desktopExtraLarge" +
+        "\nTablet: Small - $tabletSmall Normal - $tabletNormal Large - $tabletLarge ExtraLarge - $tabletExtraLarge" +
+        "\nMobile: Small - $mobileSmall Normal - $mobileNormal Large - $mobileLarge ExtraLarge - $mobileExtraLarge";
   }
 }

--- a/lib/src/widget_builders.dart
+++ b/lib/src/widget_builders.dart
@@ -17,8 +17,10 @@ class ResponsiveBuilder extends StatelessWidget {
   ) builder;
 
   final ScreenBreakpoints breakpoints;
+  final RefinedBreakpoints refinedBreakpoints;
 
-  const ResponsiveBuilder({Key key, this.builder, this.breakpoints})
+  const ResponsiveBuilder(
+      {Key key, this.builder, this.breakpoints, this.refinedBreakpoints})
       : super(key: key);
 
   @override
@@ -27,8 +29,7 @@ class ResponsiveBuilder extends StatelessWidget {
       var mediaQuery = MediaQuery.of(context);
       var sizingInformation = SizingInformation(
         deviceScreenType: getDeviceType(mediaQuery.size, breakpoints),
-        refinedSize:
-            getRefinedSize(getDeviceType(mediaQuery.size, breakpoints)),
+        refinedSize: getRefinedSize(mediaQuery.size, refinedBreakpoints),
         screenSize: mediaQuery.size,
         localWidgetSize:
             Size(boxConstraints.maxWidth, boxConstraints.maxHeight),
@@ -144,16 +145,17 @@ class ScreenTypeLayout extends StatelessWidget {
 /// [large] will be built when width is greater than 1440 on Desktops, 1024 on Tablets, and 414 on Mobiles
 /// [normal] will be built when width is greater than 1080 on Desktops, 768 on Tablets, and 375 on Mobiles
 /// [small] will be built if width is less than 720 on Desktops, 600 on Tablets, and 320 on Mobiles
-class RefinedSizeLayoutBuilder extends StatelessWidget {
-  final ScreenBreakpoints breakpoints;
+class RefinedLayoutBuilder extends StatelessWidget {
+  final RefinedBreakpoints refinedBreakpoints;
 
   final WidgetBuilder extraLarge;
   final WidgetBuilder large;
   final WidgetBuilder normal;
   final WidgetBuilder small;
 
-  const RefinedSizeLayoutBuilder({
+  const RefinedLayoutBuilder({
     Key key,
+    this.refinedBreakpoints,
     this.extraLarge,
     this.large,
     this.normal,
@@ -163,29 +165,37 @@ class RefinedSizeLayoutBuilder extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return ResponsiveBuilder(
-      breakpoints: breakpoints,
+      refinedBreakpoints: refinedBreakpoints,
       builder: (context, sizingInformation) {
         // If we're at extra large size
-        if (refinedSize == RefinedSize.extraLarge) {
+        if (sizingInformation.refinedSize == RefinedSize.extraLarge) {
           // If we have supplied the extra large layout then display that
-          if (extraLarge != null) return extraLarge;
+          if (extraLarge != null) return extraLarge(context);
           // If no extra large layout is supplied we want to check if we have the size below it and display that
-          if (large != null) return large;
+          if (large != null) return large(context);
         }
 
-        if (refinedSize == RefinedSize.large) {
+        if (sizingInformation.refinedSize == RefinedSize.large) {
           // If we have supplied the large layout then display that
-          if (large != null) return large;
+          if (large != null) return large(context);
           // If no large layout is supplied we want to check if we have the size below it and display that
-          if (normal != null) return normal;
+          if (normal != null) return normal(context);
         }
 
-        if (refinedSize == RefinedSize.small && small != null) {
-          return small;
+        if (sizingInformation.refinedSize == RefinedSize.normal) {
+          // If we have supplied the normal layout then display that
+          if (normal != null) return normal(context);
+          // If no normal layout is supplied we want to check if we have the size below it and display that
+          if (small != null) return small(context);
+        }
+
+        if (sizingInformation.refinedSize == RefinedSize.small &&
+            small != null) {
+          return small(context);
         }
 
         // If none of the layouts above are supplied or we're on the normal size layout then we show the normal layout
-        return normal;
+        return normal(context);
       },
     );
   }

--- a/lib/src/widget_builders.dart
+++ b/lib/src/widget_builders.dart
@@ -158,7 +158,7 @@ class RefinedLayoutBuilder extends StatelessWidget {
     this.refinedBreakpoints,
     this.extraLarge,
     this.large,
-    this.normal,
+    @required this.normal,
     this.small,
   }) : super(key: key);
 

--- a/lib/src/widget_builders.dart
+++ b/lib/src/widget_builders.dart
@@ -27,6 +27,8 @@ class ResponsiveBuilder extends StatelessWidget {
       var mediaQuery = MediaQuery.of(context);
       var sizingInformation = SizingInformation(
         deviceScreenType: getDeviceType(mediaQuery.size, breakpoints),
+        refinedSize:
+            getRefinedSize(getDeviceType(mediaQuery.size, breakpoints)),
         screenSize: mediaQuery.size,
         localWidgetSize:
             Size(boxConstraints.maxWidth, boxConstraints.maxHeight),
@@ -129,6 +131,61 @@ class ScreenTypeLayout extends StatelessWidget {
 
         // If none of the layouts above are supplied or we're on the mobile layout then we show the mobile layout
         return mobile(context);
+      },
+    );
+  }
+}
+
+/// Provides a builder function for refined screen sizes to be used with [ScreenTypeLayout]
+///
+/// Each builder will get built based on the current device width.
+/// [breakpoints] define your own custom device resolutions
+/// [extraLarge] will be built if width is greater than 2160 on Desktops, 1280 on Tablets, and 600 on Mobiles
+/// [large] will be built when width is greater than 1440 on Desktops, 1024 on Tablets, and 414 on Mobiles
+/// [normal] will be built when width is greater than 1080 on Desktops, 768 on Tablets, and 375 on Mobiles
+/// [small] will be built if width is less than 720 on Desktops, 600 on Tablets, and 320 on Mobiles
+class RefinedSizeLayoutBuilder extends StatelessWidget {
+  final ScreenBreakpoints breakpoints;
+
+  final WidgetBuilder extraLarge;
+  final WidgetBuilder large;
+  final WidgetBuilder normal;
+  final WidgetBuilder small;
+
+  const RefinedSizeLayoutBuilder({
+    Key key,
+    this.extraLarge,
+    this.large,
+    this.normal,
+    this.small,
+  }) : super(key: key);
+
+  @override
+  Widget build(BuildContext context) {
+    return ResponsiveBuilder(
+      breakpoints: breakpoints,
+      builder: (context, sizingInformation) {
+        // If we're at extra large size
+        if (refinedSize == RefinedSize.extraLarge) {
+          // If we have supplied the extra large layout then display that
+          if (extraLarge != null) return extraLarge;
+          // If no extra large layout is supplied we want to check if we have the size below it and display that
+          if (large != null) return large;
+        }
+
+        if (refinedSize == RefinedSize.large) {
+          // If we have supplied the large layout then display that
+          if (large != null) return large;
+          // If no large layout is supplied we want to check if we have the size below it and display that
+          if (normal != null) return normal;
+        }
+
+        if (refinedSize == RefinedSize.small && small != null) {
+          return small;
+        }
+
+        // If none of the layouts above are supplied or we're on the normal size layout then we show the normal layout
+        return normal;
       },
     );
   }


### PR DESCRIPTION
Added `RefinedLayoutBuilder` which supports small, normal, large and extraLarge layouts for each device type. Also added `getValueForRefinedSize`. Haven't updated example, readme or changelog. 

You can use `RefinedLayoutBuilder` like this:

```
ScreenTypeLayout.builder(
  mobile: (context) => RefinedLayoutBuilder(
     small:  (context) => HomeMobileSmall(),
     normal: (context) => HomeMobileNormal(),
     large: (context) => HomeMobileLarge(),
     extraLarge: (context) => HomeMobileExtraLarge()
  ),
);
```

You can use `getValueForRefinedSize` like this:

```
getValueForScreenType<double>(
  context: context,  
  mobile: getValueForRefinedSize<double>( 
     context: context, 
     small: 10,
     normal: 15,
     large: 30,
  ),
);
```
You can set `refinedBreakpoints` globally like this:
_If any breakpoints aren't set then defaults will be used. This makes it easy to just edit one platform without worrying about 12 different breakpoints._

```
void main() {
  ResponsiveSizingConfig.instance.setCustomBreakpoints(
    ScreenBreakpoints(desktop: 800, tablet: 550, watch: 200),
    customRefinedBreakpoints: RefinedBreakpoints(desktopSmall: 950, desktopNormal: 1920, desktopLarge: 3840, desktopExtraLarge: 4096),
  );
  runApp(MyApp());
}
```
