### PR TITLE
Add `isWebOrDesktop` to ResponsiveBuilder

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## Unreleased
+- Add `isWebOrDesktop` to ResponsiveBuilder. This will default to kIsWeb. 
+
 ## 0.4.0-nullsafety.1
 
 - Adds null safety and correct small refined sizing

--- a/lib/src/helpers.dart
+++ b/lib/src/helpers.dart
@@ -10,10 +10,11 @@ import 'device_screen_type.dart';
 DeviceScreenType getDeviceType(
   Size size, [
   ScreenBreakpoints? breakpoint,
+  bool? isWebOrDesktop,
 ]) {
   double deviceWidth = size.shortestSide;
 
-  if (kIsWeb) {
+  if (isWebOrDesktop ?? kIsWeb) {
     deviceWidth = size.width;
   }
 
@@ -52,12 +53,12 @@ DeviceScreenType getDeviceType(
 RefinedSize getRefinedSize(
   Size size, {
   RefinedBreakpoints? refinedBreakpoint,
-  bool isWebOrDesktop = kIsWeb,
+  bool? isWebOrDesktop,
 }) {
   DeviceScreenType deviceScreenType = getDeviceType(size);
   double deviceWidth = size.shortestSide;
 
-  if (isWebOrDesktop) {
+  if (isWebOrDesktop ?? kIsWeb) {
     deviceWidth = size.width;
   }
 

--- a/lib/src/widget_builders.dart
+++ b/lib/src/widget_builders.dart
@@ -18,12 +18,14 @@ class ResponsiveBuilder extends StatelessWidget {
 
   final ScreenBreakpoints? breakpoints;
   final RefinedBreakpoints? refinedBreakpoints;
+  final bool? isWebOrDesktop;
 
   const ResponsiveBuilder({
     Key? key,
     required this.builder,
     this.breakpoints,
     this.refinedBreakpoints,
+    this.isWebOrDesktop,
   }) : super(key: key);
 
   @override
@@ -31,11 +33,11 @@ class ResponsiveBuilder extends StatelessWidget {
     return LayoutBuilder(builder: (context, boxConstraints) {
       var mediaQuery = MediaQuery.of(context);
       var sizingInformation = SizingInformation(
-        deviceScreenType: getDeviceType(mediaQuery.size, breakpoints),
-        refinedSize: getRefinedSize(
-          mediaQuery.size,
-          refinedBreakpoint: refinedBreakpoints,
-        ),
+        deviceScreenType:
+            getDeviceType(mediaQuery.size, breakpoints, isWebOrDesktop),
+        refinedSize: getRefinedSize(mediaQuery.size,
+            refinedBreakpoint: refinedBreakpoints,
+            isWebOrDesktop: isWebOrDesktop),
         screenSize: mediaQuery.size,
         localWidgetSize:
             Size(boxConstraints.maxWidth, boxConstraints.maxHeight),


### PR DESCRIPTION
Fixes #31

Fixes the issues on all Desktop platforms when the window is wider than the height and mean it used the tablet sizes. 

This change ensures that width=Size.width rather than width=Size.shortest when on Web and Desktop. The code was there in the getDeviceTypes and getRefindedSize but it was either was not configurable and stuck as kIsWeb or had a parameter and defaulted. I have added a parameter to ResponsiveBuilder to allow this to be overridden. Currently, it just defaults to kIsWeb as this was the existing behaviour.

Example
```
ResponsiveBuilder(
      isWebOrDesktop: kIsWeb || Theme.of(context).platform.isDesktop(), // Using an extension function to determine isDesktop
      builder: (context, sizingInformation) {
 ...
}
```

Extra. If anyone wants the extension function to use the above
```
extension PlatformCheck on TargetPlatform {
  bool isDesktop() {
    return [TargetPlatform.macOS, TargetPlatform.windows, TargetPlatform.linux]
        .contains(this);
  }
}
```

To use the code in this PR in your app:
```
  responsive_builder:
    git:
      url: git://github.com/georgeherby/responsive_builder.git
      ref: master
```