### PR TITLE
Added Desktop platform checks.

### DIFF
--- a/lib/src/helpers.dart
+++ b/lib/src/helpers.dart
@@ -15,11 +15,7 @@ DeviceScreenType getDeviceType(
 ]) {
   double deviceWidth = size.shortestSide;
 
-  if (kIsWeb) {
-    deviceWidth = size.width;
-  } else {
-    //Check if the device is a desktop, should not be web
-    if (Platform.isMacOS || Platform.isWindows || Platform.isLinux) {
+    if (kIsWeb || Platform.isMacOS || Platform.isWindows || Platform.isLinux) { 
       deviceWidth = size.width;
     }
   }

--- a/lib/src/helpers.dart
+++ b/lib/src/helpers.dart
@@ -1,3 +1,5 @@
+import 'dart:io';
+
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:responsive_builder/src/responsive_sizing_config.dart';
@@ -15,6 +17,11 @@ DeviceScreenType getDeviceType(
 
   if (kIsWeb) {
     deviceWidth = size.width;
+  } else {
+    //Check if the device is a desktop, should not be web
+    if (Platform.isMacOS || Platform.isWindows || Platform.isLinux) {
+      deviceWidth = size.width;
+    }
   }
 
   // Replaces the defaults with the user defined definitions


### PR DESCRIPTION
Fixes #31 
#36 requires the developer to parse a variable to the ResponsiveBuilder.

On Desktop (Windows and macOS - I did not test Linux), the tablet builder would be used even when in full-screen mode. This however did not happen in Web. 

I added the following because I did not want to depend on universal_io. This uses dart:io (which is not supported on the web). It is only called when the app is compiled for desktop, mobile, and not web.

` if (kIsWeb) {
    deviceWidth = size.width;
  } else {
    //Check if the device is a desktop, should not be web
    if (Platform.isMacOS || Platform.isWindows || Platform.isLinux) {
      deviceWidth = size.width;
    }
  }`

