### PR TITLE
Optimize MediaQuery usage to prevent unnecessary rebuilds

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,7 +168,7 @@ Container(
 What if you ONLY want to update the padding based on the device screen size. You could do.
 
 ```dart
-var deviceType = getDeviceType(MediaQuery.of(context).size);
+var deviceType = getDeviceType(MediaQuery.sizeOf(context));
 var paddingValue = 0;
 switch(deviceType) {
   case DeviceScreenType.desktop:

--- a/example/lib/views/home/home_view_tablet.dart
+++ b/example/lib/views/home/home_view_tablet.dart
@@ -12,7 +12,7 @@ class HomeViewTablet extends StatelessWidget {
       ),
       AppDrawer()
     ];
-    var orientation = MediaQuery.of(context).orientation;
+    var orientation = MediaQuery.orientationOf(context);
     return Scaffold(
       body: orientation == Orientation.portrait
           ? Column(children: children)

--- a/example/lib/widgets/app_drawer/app_drawer_mobile.dart
+++ b/example/lib/widgets/app_drawer/app_drawer_mobile.dart
@@ -7,7 +7,7 @@ class AppDrawerMobile extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    var orientation = MediaQuery.of(context).orientation;
+    var orientation = MediaQuery.orientationOf(context);
     return Container(
       width: orientation == Orientation.portrait ? 250 : 100,
       decoration: BoxDecoration(color: Colors.white, boxShadow: [
@@ -16,7 +16,9 @@ class AppDrawerMobile extends StatelessWidget {
           color: Colors.black12,
         )
       ]),
-      child: Column(children: AppDrawer.getDrawerOptions(),),
+      child: Column(
+        children: AppDrawer.getDrawerOptions(),
+      ),
     );
   }
 }

--- a/lib/src/helpers/helpers.dart
+++ b/lib/src/helpers/helpers.dart
@@ -173,7 +173,7 @@ T getValueForScreenType<T>({
   T? desktop,
   T? watch,
 }) {
-  var deviceScreenType = getDeviceType(MediaQuery.of(context).size);
+  var deviceScreenType = getDeviceType(MediaQuery.sizeOf(context));
   // If we're at desktop size
   if (deviceScreenType == DeviceScreenType.desktop) {
     // If we have supplied the desktop layout then display that
@@ -208,7 +208,7 @@ T getValueForRefinedSize<T>({
   T? extraLarge,
   T? small,
 }) {
-  var refinedSize = getRefinedSize(MediaQuery.of(context).size);
+  var refinedSize = getRefinedSize(MediaQuery.sizeOf(context));
   // If we're at extra large size
   if (refinedSize == RefinedSize.extraLarge) {
     // If we have supplied the extra large layout then display that

--- a/lib/src/widget_builders.dart
+++ b/lib/src/widget_builders.dart
@@ -26,14 +26,14 @@ class ResponsiveBuilder extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return LayoutBuilder(builder: (context, boxConstraints) {
-      var mediaQuery = MediaQuery.of(context);
+      var size = MediaQuery.sizeOf(context);
       var sizingInformation = SizingInformation(
-        deviceScreenType: getDeviceType(mediaQuery.size, breakpoints),
+        deviceScreenType: getDeviceType(size, breakpoints),
         refinedSize: getRefinedSize(
-          mediaQuery.size,
+          size,
           refinedBreakpoint: refinedBreakpoints,
         ),
-        screenSize: mediaQuery.size,
+        screenSize: size,
         localWidgetSize:
             Size(boxConstraints.maxWidth, boxConstraints.maxHeight),
       );


### PR DESCRIPTION
**Description:**

In this PR, I've _optimized_ the way we access MediaQuery properties by using _MediaQuery.propertyOf_ instead of relying on the traditional _MediaQuery.of(context)_ method. This ensures that we get the latest MediaQuery data without triggering unnecessary rebuilds across the app, improving performance as highlighted in the **Flutter team's best practices video** [here](https://www.youtube.com/watch?v=xVk1kPvkgAY).

**Changes:**

- Replaced MediaQuery.of(context) with MediaQuery.propertyOf in relevant places.
- Updated affected widgets/components to ensure they receive the latest MediaQuery data while maintaining optimal performance.
